### PR TITLE
Feature/ecr multi account policy

### DIFF
--- a/.github/templates/ecr-multi-account.json
+++ b/.github/templates/ecr-multi-account.json
@@ -1,0 +1,25 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "AllowPushPull",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": [
+            "arn:aws:iam::963320629986:root",
+            "arn:aws:iam::817969952797:root",
+            "arn:aws:iam::479886561928:root"
+          ]
+        },
+        "Action": [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:CompleteLayerUpload",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage",
+          "ecr:UploadLayerPart"
+        ]
+      }
+    ]
+  }

--- a/.github/templates/ecr-policy.json
+++ b/.github/templates/ecr-policy.json
@@ -10,23 +10,68 @@
           "countNumber": 99999,
           "tagStatus": "tagged",
           "tagPrefixList": [
-            "develop",
-            "main",
-            "release",
             "dev"
           ]
         },
-        "description": "Keep images with tags \"develop\", \"main\" or \"release\".",
+        "description": "Keep images with tags \"dev\".",
         "rulePriority": 1
       },
       {
-        "rulePriority": 2,
+        "action": {
+          "type": "expire"
+        },
+        "selection": {
+          "countType": "sinceImagePushed",
+          "countUnit": "days",
+          "countNumber": 99999,
+          "tagStatus": "tagged",
+          "tagPrefixList": [
+            "main"
+          ]
+        },
+        "description": "Keep images with tags \"main\".",
+        "rulePriority": 2
+      },
+      {
+        "action": {
+          "type": "expire"
+        },
+        "selection": {
+          "countType": "sinceImagePushed",
+          "countUnit": "days",
+          "countNumber": 99999,
+          "tagStatus": "tagged",
+          "tagPrefixList": [
+            "prod"
+          ]
+        },
+        "description": "Keep images with tags \"prod\".",
+        "rulePriority": 3
+      },
+      {
+        "action": {
+          "type": "expire"
+        },
+        "selection": {
+          "countType": "sinceImagePushed",
+          "countUnit": "days",
+          "countNumber": 99999,
+          "tagStatus": "tagged",
+          "tagPrefixList": [
+            "release"
+          ]
+        },
+        "description": "Keep images with tags \"release\".",
+        "rulePriority": 4
+      },
+      {
+        "rulePriority": 5,
         "description": "Expire all images after 10 days, (The images found with the rules above will not be affected since their priority is higher).",
         "selection": {
           "tagStatus": "any",
           "countType": "sinceImagePushed",
           "countUnit": "days",
-          "countNumber": 10
+          "countNumber": 20
         },
         "action": {
           "type": "expire"

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -64,8 +64,8 @@ jobs:
 
       - name: Lifecycle policy check/creation
         run: |
-          aws ecr get-lifecycle-policy --repository-name ${{ inputs.service_name }} \
-          || aws ecr put-lifecycle-policy --repository-name ${{ inputs.service_name }} \
+          # aws ecr get-lifecycle-policy --repository-name ${{ inputs.service_name }} || \
+          aws ecr put-lifecycle-policy --repository-name ${{ inputs.service_name }} \
           --lifecycle-policy-text '${{ steps.default_ecr_policy.outputs.policy }}'
 
       - name: Multi account permission policy set

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -78,8 +78,8 @@ jobs:
           # end of optional handling for multi line json
           aws ecr set-repository-policy \
             --repository-name ${{ inputs.service_name }} \
-            --policy-text $content
-
+            --policy-text "$content"
+            
       - name: Login to ECR
         uses: docker/login-action@v2.0.0
         with:

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -70,11 +70,15 @@ jobs:
       - name: Multi account permission policy set
         # working-directory: .github/templates
         run: |
-          pwd
-          ls
+          content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/ecr-multi-account-policy/.github/templates/ecr-multi-account.json`
+          # the following lines are only required for multi line json
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
+          # end of optional handling for multi line json
           aws ecr set-repository-policy \
             --repository-name ${{ inputs.service_name }} \
-            --policy-text file://ecr-multi-account.json
+            --policy-text $content #file://ecr-multi-account.json
 
       - name: Login to ECR
         uses: docker/login-action@v2.0.0

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -51,22 +51,35 @@ jobs:
           aws ecr describe-repositories --repository-names ${{ inputs.service_name }} \
           || aws ecr create-repository --repository-name ${{ inputs.service_name }}
 
+      # - name: Download ecr policy 
+      #   id: default_ecr_policy
+      #   run: |
+      #     content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/main/.github/templates/ecr-policy.json`
+      #     # the following lines are only required for multi line json
+      #     content="${content//'%'/'%25'}"
+      #     content="${content//$'\n'/'%0A'}"
+      #     content="${content//$'\r'/'%0D'}"
+      #     # end of optional handling for multi line json
+      #     echo "policy=$content" >> $GITHUB_OUTPUT
+
       - name: Download ecr policy 
         id: default_ecr_policy
         run: |
           content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/feature/ecr-multi-account-policy/.github/templates/ecr-policy.json`
           # the following lines are only required for multi line json
-          #content="${content//'%'/'%25'}"
-          #content="${content//$'\n'/'%0A'}"
-          #content="${content//$'\r'/'%0D'}"
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
           echo "policy=$content" >> $GITHUB_OUTPUT
+
 
       - name: Lifecycle policy check/creation
         run: |
           # aws ecr get-lifecycle-policy --repository-name ${{ inputs.service_name }} || \
+          curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/feature/ecr-multi-account-policy/.github/templates/ecr-policy.json >> ecr-policy.json
           aws ecr put-lifecycle-policy --repository-name ${{ inputs.service_name }} \
-          --lifecycle-policy-text '${{ steps.default_ecr_policy.outputs.policy }}'
+          --lifecycle-policy-text file://ecr-policy.json #'${{ steps.default_ecr_policy.outputs.policy }}'
 
       - name: Multi account permission policy set
         run: |

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -46,6 +46,34 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
           aws-region: ${{ inputs.aws_ci_region }}
 
+      - name: Repository check/creation
+        run: |
+          aws ecr describe-repositories --repository-names ${{ inputs.service_name }} \
+          || aws ecr create-repository --repository-name ${{ inputs.service_name }}
+
+      - id: default_ecr_policy
+        run: |
+          content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/main/.github/templates/ecr-policy.json`
+          # the following lines are only required for multi line json
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
+          # end of optional handling for multi line json
+          echo "::set-output name=policy::$content"
+
+      - name: Lifecycle policy check/creation
+        run: |
+          aws ecr get-lifecycle-policy --repository-name ${{ inputs.service_name }} \
+          || aws ecr put-lifecycle-policy --repository-name ${{ inputs.service_name }} \
+          --lifecycle-policy-text '${{ steps.default_ecr_policy.outputs.policy }}'
+
+      - name: Multi account permission policy set
+        working-directory: ./.github/templates
+        run: |
+          aws ecr set-repository-policy \
+            --repository-name ${{ inputs.service_name }} \
+            --policy-text file://ecr-multi-account.json
+
       - name: Login to ECR
         uses: docker/login-action@v2.0.0
         with:
@@ -54,6 +82,7 @@ jobs:
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
           ecr: true
           logout: true
+
       - name: Replace branch name bad chars
         id: branch_name
         run: |
@@ -64,6 +93,7 @@ jobs:
             name=$( echo '${{ github.ref_name }}' | tr '/' '-' )
             echo "::set-output name=branch_name::$name"
           fi
+
       - name: Calc Short SHA
         id: short_sha 
         run: |
@@ -77,7 +107,8 @@ jobs:
           push: true
           tags: 
                 ${{ inputs.aws_ci_account }}.${{ env.repository }}:${{ steps.short_sha.outputs.short_sha }},
-                ${{ inputs.aws_ci_account }}.${{ env.repository }}:${{ steps.branch_name.outputs.branch_name }}
+                ${{ inputs.aws_ci_account }}.${{ env.repository }}:${{ steps.branch_name.outputs.branch_name }},
+                ${{ inputs.aws_ci_account }}.${{ env.repository }}:${{ github.run_id }}
           file: ${{ inputs.dockerfile_path }} 
 
 

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -59,7 +59,6 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
-          # echo "::set-output name=policy::$content"
           echo "policy=$content" >> $GITHUB_OUTPUT
 
       - name: Lifecycle policy check/creation
@@ -69,7 +68,6 @@ jobs:
           --lifecycle-policy-text '${{ steps.default_ecr_policy.outputs.policy }}'
 
       - name: Multi account permission policy set
-        # working-directory: .github/templates
         run: |
           content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/feature/ecr-multi-account-policy/.github/templates/ecr-multi-account.json`
           # the following lines are only required for multi line json
@@ -95,11 +93,9 @@ jobs:
         run: |
           if [ ${{ github.event_name }} == "pull_request" ]; then
             name=$( echo '${{ github.head_ref }}' | tr '/' '-' )
-            # echo "::set-output name=branch_name::$name"
             echo "branch_name=$name" >> $GITHUB_OUTPUT
           else
             name=$( echo '${{ github.ref_name }}' | tr '/' '-' )
-            # echo "::set-output name=branch_name::$name"
             echo "branch_name=$name" >> $GITHUB_OUTPUT
           fi
 
@@ -107,7 +103,6 @@ jobs:
         id: short_sha 
         run: |
             short_sha=$(git rev-parse --short "$GITHUB_SHA")
-            # echo "::set-output name=short_sha::$short_sha"
             echo "short_sha=$short_sha" >> $GITHUB_OUTPUT
             
       - name: Docker build and push

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -76,6 +76,7 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
+          echo $content
           aws ecr set-repository-policy \
             --repository-name ${{ inputs.service_name }} \
             --policy-text $content 

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -70,17 +70,15 @@ jobs:
       - name: Multi account permission policy set
         # working-directory: .github/templates
         run: |
-          content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/ecr-multi-account-policy/.github/templates/ecr-multi-account.json`
+          content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/feature/ecr-multi-account-policy/.github/templates/ecr-multi-account.json`
           # the following lines are only required for multi line json
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
-          echo $content
           aws ecr set-repository-policy \
             --repository-name ${{ inputs.service_name }} \
-            --policy-text $content 
-          #file://ecr-multi-account.json
+            --policy-text $content
 
       - name: Login to ECR
         uses: docker/login-action@v2.0.0

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -62,36 +62,19 @@ jobs:
       #     # end of optional handling for multi line json
       #     echo "policy=$content" >> $GITHUB_OUTPUT
 
-      - name: Download ecr policy 
-        id: default_ecr_policy
-        run: |
-          content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/feature/ecr-multi-account-policy/.github/templates/ecr-policy.json`
-          # the following lines are only required for multi line json
-          content="${content//'%'/'%25'}"
-          content="${content//$'\n'/'%0A'}"
-          content="${content//$'\r'/'%0D'}"
-          # end of optional handling for multi line json
-          echo "policy=$content" >> $GITHUB_OUTPUT
-
-
       - name: Lifecycle policy check/creation
         run: |
           # aws ecr get-lifecycle-policy --repository-name ${{ inputs.service_name }} || \
-          curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/feature/ecr-multi-account-policy/.github/templates/ecr-policy.json >> ecr-policy.json
+          curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/main/.github/templates/ecr-policy.json >> ecr-policy.json
           aws ecr put-lifecycle-policy --repository-name ${{ inputs.service_name }} \
           --lifecycle-policy-text file://ecr-policy.json #'${{ steps.default_ecr_policy.outputs.policy }}'
 
       - name: Multi account permission policy set
         run: |
-          content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/feature/ecr-multi-account-policy/.github/templates/ecr-multi-account.json`
-          # the following lines are only required for multi line json
-          #content="${content//'%'/'%25'}"
-          #content="${content//$'\n'/'%0A'}"
-          #content="${content//$'\r'/'%0D'}"
-          # end of optional handling for multi line json
+          curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/main/.github/templates/ecr-multi-account.json >> ecr-multi-account.json
           aws ecr set-repository-policy \
             --repository-name ${{ inputs.service_name }} \
-            --policy-text "$content"
+            --policy-text file://ecr-multi-account.json
             
       - name: Login to ECR
         uses: docker/login-action@v2.0.0

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -59,7 +59,8 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
-          echo "::set-output name=policy::$content"
+          # echo "::set-output name=policy::$content"
+          echo "{policy}={$content}" >> $GITHUB_OUTPUT
 
       - name: Lifecycle policy check/creation
         run: |

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -60,7 +60,7 @@ jobs:
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
           # echo "::set-output name=policy::$content"
-          echo "{policy}={$content}" >> $GITHUB_OUTPUT
+          echo "policy=$content" >> $GITHUB_OUTPUT
 
       - name: Lifecycle policy check/creation
         run: |
@@ -95,17 +95,20 @@ jobs:
         run: |
           if [ ${{ github.event_name }} == "pull_request" ]; then
             name=$( echo '${{ github.head_ref }}' | tr '/' '-' )
-            echo "::set-output name=branch_name::$name"
+            # echo "::set-output name=branch_name::$name"
+            echo "name=$name" >> $GITHUB_OUTPUT
           else
             name=$( echo '${{ github.ref_name }}' | tr '/' '-' )
-            echo "::set-output name=branch_name::$name"
+            # echo "::set-output name=branch_name::$name"
+            echo "branch_name=$name" >> $GITHUB_OUTPUT
           fi
 
       - name: Calc Short SHA
         id: short_sha 
         run: |
             short_sha=$(git rev-parse --short "$GITHUB_SHA")
-            echo "::set-output name=short_sha::$short_sha"
+            # echo "::set-output name=short_sha::$short_sha"
+            echo "short_sha=$short_sha" >> $GITHUB_OUTPUT
             
       - name: Docker build and push
         uses: docker/build-push-action@v3.2.0

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -96,7 +96,7 @@ jobs:
           if [ ${{ github.event_name }} == "pull_request" ]; then
             name=$( echo '${{ github.head_ref }}' | tr '/' '-' )
             # echo "::set-output name=branch_name::$name"
-            echo "name=$name" >> $GITHUB_OUTPUT
+            echo "branch_name=$name" >> $GITHUB_OUTPUT
           else
             name=$( echo '${{ github.ref_name }}' | tr '/' '-' )
             # echo "::set-output name=branch_name::$name"

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -51,7 +51,8 @@ jobs:
           aws ecr describe-repositories --repository-names ${{ inputs.service_name }} \
           || aws ecr create-repository --repository-name ${{ inputs.service_name }}
 
-      - id: default_ecr_policy
+      - name: Download ecr policy 
+        id: default_ecr_policy
         run: |
           content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/feature/ecr-multi-account-policy/.github/templates/ecr-policy.json`
           # the following lines are only required for multi line json

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -56,9 +56,9 @@ jobs:
         run: |
           content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/feature/ecr-multi-account-policy/.github/templates/ecr-policy.json`
           # the following lines are only required for multi line json
-          content="${content//'%'/'%25'}"
-          content="${content//$'\n'/'%0A'}"
-          content="${content//$'\r'/'%0D'}"
+          #content="${content//'%'/'%25'}"
+          #content="${content//$'\n'/'%0A'}"
+          #content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
           echo "policy=$content" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -68,8 +68,10 @@ jobs:
           --lifecycle-policy-text '${{ steps.default_ecr_policy.outputs.policy }}'
 
       - name: Multi account permission policy set
-        working-directory: .github/templates
+        # working-directory: .github/templates
         run: |
+          pwd
+          ls
           aws ecr set-repository-policy \
             --repository-name ${{ inputs.service_name }} \
             --policy-text file://ecr-multi-account.json

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -78,7 +78,8 @@ jobs:
           # end of optional handling for multi line json
           aws ecr set-repository-policy \
             --repository-name ${{ inputs.service_name }} \
-            --policy-text $content #file://ecr-multi-account.json
+            --policy-text $content 
+          #file://ecr-multi-account.json
 
       - name: Login to ECR
         uses: docker/login-action@v2.0.0

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - id: default_ecr_policy
         run: |
-          content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/main/.github/templates/ecr-policy.json`
+          content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/feature/ecr-multi-account-policy/.github/templates/ecr-policy.json`
           # the following lines are only required for multi line json
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -68,7 +68,7 @@ jobs:
           --lifecycle-policy-text '${{ steps.default_ecr_policy.outputs.policy }}'
 
       - name: Multi account permission policy set
-        working-directory: ./.github/templates
+        working-directory: .github/templates
         run: |
           aws ecr set-repository-policy \
             --repository-name ${{ inputs.service_name }} \

--- a/.github/workflows/build-and-push-ecr.yaml
+++ b/.github/workflows/build-and-push-ecr.yaml
@@ -72,9 +72,9 @@ jobs:
         run: |
           content=`curl https://raw.githubusercontent.com/brightsource-il/github-actions-template/feature/ecr-multi-account-policy/.github/templates/ecr-multi-account.json`
           # the following lines are only required for multi line json
-          content="${content//'%'/'%25'}"
-          content="${content//$'\n'/'%0A'}"
-          content="${content//$'\r'/'%0D'}"
+          #content="${content//'%'/'%25'}"
+          #content="${content//$'\n'/'%0A'}"
+          #content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
           aws ecr set-repository-policy \
             --repository-name ${{ inputs.service_name }} \


### PR DESCRIPTION
build-and-push-ecr.yaml:
fixed deprecated set-output commands
added missing repo check/creation and lifecycle policy check/creation steps
added step to add "qa" and "prod" account access to dev ECR in repo permissions
added ecr-multi-account.json to templates for previous added step use

fixed bug in ecr-policy.json that would delete tagged images that were not intended for deletion.