### PR TITLE
Localstack support

### DIFF
--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
         default: "./Python/bsii_cloud/bsii_cloud_storage/storage_tests/s3-wrapper_test.py"
+      localstack-docker-compose:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   test:
@@ -27,3 +31,4 @@ jobs:
       requirements-path: ${{ inputs.requirements-path }}
       test-file-path: ${{ inputs.test-path }}
       setup-config-path: ${{ inputs.setup-config-path }}
+      localstack-docker-compose: ${{inputs.localstack-docker-compose}}

--- a/.github/workflows/ci-service-python.yaml
+++ b/.github/workflows/ci-service-python.yaml
@@ -43,6 +43,10 @@ on:
         required: false
         type: boolean
         default: false
+      localstack-docker-compose:
+        required: false
+        type: string
+        default: ""
 
     outputs:
       run_id:
@@ -62,6 +66,7 @@ jobs:
       requirements-path: ${{ inputs. requirements-path }}
       test-file-path: ${{ inputs.test-file-path }}
       setup-config-path: ${{ inputs.setup-config-path }}
+      localstack-docker-compose: ${{ inputs.localstack-docker-compose }}
 
   sonarqube:
     if: ${{ inputs.enable-sonarqube }}

--- a/.github/workflows/ci-services.yaml
+++ b/.github/workflows/ci-services.yaml
@@ -39,6 +39,10 @@ on:
       test-file-path:
         required: false
         type: string
+      localstack-docker-compose:
+          required: false
+          type: string
+          default: ""
 
     outputs:
       services:
@@ -115,6 +119,7 @@ jobs:
       enable-sonarqube: ${{ inputs.enable-sonarqube }}
       test-file-path: ${{ inputs.test-file-path }}
       enable-test: ${{ inputs.enable-test }}
+      localstack-docker-compose: ${{ inputs.localstack-docker-compose }}
 
   ci-service-default:
     if: ${{ inputs.service_type != 'csharp' && inputs.service_type != 'python' }}

--- a/.github/workflows/python-unit-test.yaml
+++ b/.github/workflows/python-unit-test.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup LocalStack
         if: "${{ inputs.localstack-docker-compose != '' }}"
         run: |
-          docker-compose -f ${{ inputs.localstack-docker-compose }} up -d
+          docker-compose -f $NORMALIZED_COMPOSE_PATH up -d
           pip install awscli-local
           while ! awslocal s3api list-buckets ; do
               echo "Waiting for LocalStack to be ready..."

--- a/.github/workflows/python-unit-test.yaml
+++ b/.github/workflows/python-unit-test.yaml
@@ -19,6 +19,10 @@ on:
       aws_ci_region:
         type: string
         default: "us-east-1"
+      localstack-docker-compose:
+        required: false
+        type: string
+        default: ""
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -43,23 +47,30 @@ jobs:
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
       - name: Install dependencies
-        if: "${{ inputs. requirements-path != '' }}"
+        if: "${{ inputs.requirements-path != '' }}"
         run: |
           python -m pip install --upgrade pip
-          pip install -r ${{ inputs. requirements-path }}
+          pip install -r ${{ inputs.requirements-path }}
 
       - name: Install dependencies of package
         if: "${{ inputs.setup-config-path != '' }}"
         run: |
           pip install ${{ inputs.setup-config-path }}
 
-      - name: Test with unittest
+      - name: Setup LocalStack
+        if: "${{ inputs.localstack-docker-compose != '' }}"
         run: |
-          python -m unittest
-          python -m unittest  ${{ inputs.test-file-path }}
+          docker-compose -f ${{ inputs.localstack-docker-compose }} up -d
+          pip install awscli-local
+          while ! awslocal s3api list-buckets ; do
+              echo "Waiting for LocalStack to be ready..."
+              sleep 2
+          done
+
+      - name: Test with unittest
+        run: python -m unittest ${{ inputs.test-file-path }}
+
+      - name: Cleanup LocalStack
+        if: "${{ inputs.localstack-docker-compose != '' }}"
+        run: docker-compose -f ${{ inputs.localstack-docker-compose }} down

--- a/.github/workflows/python-unit-test.yaml
+++ b/.github/workflows/python-unit-test.yaml
@@ -79,6 +79,6 @@ jobs:
       - name: Test with unittest
         run: python -m unittest ${{ inputs.test-file-path }}
 
-      - name: Cleanup LocalStack
+      - name: Post Setup LocalStack
         if: "${{ inputs.localstack-docker-compose != '' }}"
         run: docker-compose -f ${{ inputs.localstack-docker-compose }} down

--- a/.github/workflows/python-unit-test.yaml
+++ b/.github/workflows/python-unit-test.yaml
@@ -57,6 +57,14 @@ jobs:
         if: "${{ inputs.setup-config-path != '' }}"
         run: |
           pip install ${{ inputs.setup-config-path }}
+          
+      - name: Fix docker-compose path (remove './' from beginning)
+        run: |
+          INPUT_PATH="${{ inputs.localstack-docker-compose }}"
+          if [[ "$INPUT_PATH" == ./* ]]; then
+              INPUT_PATH="${INPUT_PATH:2}"
+          fi
+          echo "NORMALIZED_COMPOSE_PATH=$INPUT_PATH" >> $GITHUB_ENV      
 
       - name: Setup LocalStack
         if: "${{ inputs.localstack-docker-compose != '' }}"


### PR DESCRIPTION
add an option to set up LocalStack before testing, for integration tests with AWS

currently in use in [cloud-foundations](https://github.com/brightsource-il/cloud-foundations),
but we can use it in ThermAlgo also (we have to add Terraform support also)
